### PR TITLE
fix: add impls

### DIFF
--- a/bootstrap/src/main/java/com/github/j5ik2o/cqrs/es/java/main/CommandLineRunnerImpl.java
+++ b/bootstrap/src/main/java/com/github/j5ik2o/cqrs/es/java/main/CommandLineRunnerImpl.java
@@ -1,0 +1,12 @@
+package com.github.j5ik2o.cqrs.es.java.main;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("local-rmu")
+public class CommandLineRunnerImpl implements CommandLineRunner {
+  @Override
+  public void run(String... args) throws Exception {}
+}

--- a/bootstrap/src/main/resources/application-local-rmu.yml
+++ b/bootstrap/src/main/resources/application-local-rmu.yml
@@ -1,0 +1,3 @@
+spring:
+  main:
+    web-application-type: none

--- a/command/interface-adaptor-impl/src/main/java/com/github/j5ik2o/cqrs/es/java/command/interface_adaptor/repository/RepositoryConfig.java
+++ b/command/interface-adaptor-impl/src/main/java/com/github/j5ik2o/cqrs/es/java/command/interface_adaptor/repository/RepositoryConfig.java
@@ -10,9 +10,11 @@ import io.vavr.control.Option;
 import java.util.function.BiPredicate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 
 @Configuration
+@Profile("write")
 public class RepositoryConfig {
   private static final String JOURNAL_TABLE_NAME = "journal";
   private static final String SNAPSHOT_TABLE_NAME = "snapshot";

--- a/command/interface-adaptor-impl/src/main/java/com/github/j5ik2o/cqrs/es/java/command/interface_adaptor/repository/serialization/GroupChatEventSerializer.java
+++ b/command/interface-adaptor-impl/src/main/java/com/github/j5ik2o/cqrs/es/java/command/interface_adaptor/repository/serialization/GroupChatEventSerializer.java
@@ -2,12 +2,8 @@ package com.github.j5ik2o.cqrs.es.java.command.interface_adaptor.repository.seri
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.github.f4b6a3.ulid.Ulid;
 import com.github.j5ik2o.cqrs.es.java.domain.groupchat.GroupChatEvent;
 import com.github.j5ik2o.cqrs.es.java.domain.groupchat.GroupChatId;
-import com.github.j5ik2o.cqrs.es.java.domain.groupchat.Members;
-import com.github.j5ik2o.cqrs.es.java.domain.groupchat.Messages;
 import com.github.j5ik2o.event.store.adapter.java.DeserializationException;
 import com.github.j5ik2o.event.store.adapter.java.EventSerializer;
 import com.github.j5ik2o.event.store.adapter.java.SerializationException;
@@ -16,29 +12,18 @@ import javax.annotation.Nonnull;
 
 public final class GroupChatEventSerializer
     implements EventSerializer<GroupChatId, GroupChatEvent> {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
-  private static void configureModule() {
-    SimpleModule module = new SimpleModule();
-    module.addSerializer(Ulid.class, new UlidJsonSerializer());
-    module.addDeserializer(Ulid.class, new UlidJsonDeserializer());
-    module.addSerializer(Members.class, new MembersJsonSerializer());
-    module.addDeserializer(Members.class, new MembersJsonDeserializer());
-    module.addSerializer(Messages.class, new MessagesJsonSerializer());
-    module.addDeserializer(Messages.class, new MessagesJsonDeserializer());
-    objectMapper.registerModule(module);
-    objectMapper.findAndRegisterModules();
-  }
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   static {
-    configureModule();
+    OBJECT_MAPPER.registerModule(JacksonModuleFactory.create());
+    OBJECT_MAPPER.findAndRegisterModules();
   }
 
   @Nonnull
   @Override
   public byte[] serialize(@Nonnull GroupChatEvent groupChatEvent) throws SerializationException {
     try {
-      return objectMapper.writeValueAsBytes(groupChatEvent);
+      return OBJECT_MAPPER.writeValueAsBytes(groupChatEvent);
     } catch (JsonProcessingException e) {
       throw new SerializationException(e);
     }
@@ -49,7 +34,7 @@ public final class GroupChatEventSerializer
   public GroupChatEvent deserialize(@Nonnull byte[] bytes, @Nonnull Class<GroupChatEvent> clazz)
       throws DeserializationException {
     try {
-      return objectMapper.readValue(bytes, clazz);
+      return OBJECT_MAPPER.readValue(bytes, clazz);
     } catch (IOException e) {
       throw new DeserializationException(e);
     }

--- a/command/interface-adaptor-impl/src/main/java/com/github/j5ik2o/cqrs/es/java/command/interface_adaptor/repository/serialization/GroupChatSnapshotSerializer.java
+++ b/command/interface-adaptor-impl/src/main/java/com/github/j5ik2o/cqrs/es/java/command/interface_adaptor/repository/serialization/GroupChatSnapshotSerializer.java
@@ -2,12 +2,8 @@ package com.github.j5ik2o.cqrs.es.java.command.interface_adaptor.repository.seri
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.github.f4b6a3.ulid.Ulid;
 import com.github.j5ik2o.cqrs.es.java.domain.groupchat.GroupChat;
 import com.github.j5ik2o.cqrs.es.java.domain.groupchat.GroupChatId;
-import com.github.j5ik2o.cqrs.es.java.domain.groupchat.Members;
-import com.github.j5ik2o.cqrs.es.java.domain.groupchat.Messages;
 import com.github.j5ik2o.event.store.adapter.java.DeserializationException;
 import com.github.j5ik2o.event.store.adapter.java.SerializationException;
 import com.github.j5ik2o.event.store.adapter.java.SnapshotSerializer;
@@ -16,29 +12,18 @@ import javax.annotation.Nonnull;
 
 public final class GroupChatSnapshotSerializer
     implements SnapshotSerializer<GroupChatId, GroupChat> {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
-
-  private static void configureModule() {
-    SimpleModule module = new SimpleModule();
-    module.addSerializer(Ulid.class, new UlidJsonSerializer());
-    module.addDeserializer(Ulid.class, new UlidJsonDeserializer());
-    module.addSerializer(Members.class, new MembersJsonSerializer());
-    module.addDeserializer(Members.class, new MembersJsonDeserializer());
-    module.addSerializer(Messages.class, new MessagesJsonSerializer());
-    module.addDeserializer(Messages.class, new MessagesJsonDeserializer());
-    objectMapper.registerModule(module);
-    objectMapper.findAndRegisterModules();
-  }
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   static {
-    configureModule();
+    OBJECT_MAPPER.registerModule(JacksonModuleFactory.create());
+    OBJECT_MAPPER.findAndRegisterModules();
   }
 
   @Nonnull
   @Override
   public byte[] serialize(@Nonnull GroupChat groupChat) throws SerializationException {
     try {
-      return objectMapper.writeValueAsBytes(groupChat);
+      return OBJECT_MAPPER.writeValueAsBytes(groupChat);
     } catch (JsonProcessingException e) {
       throw new SerializationException(e);
     }
@@ -49,7 +34,7 @@ public final class GroupChatSnapshotSerializer
   public GroupChat deserialize(@Nonnull byte[] bytes, @Nonnull Class<GroupChat> clazz)
       throws DeserializationException {
     try {
-      return objectMapper.readValue(bytes, clazz);
+      return OBJECT_MAPPER.readValue(bytes, clazz);
     } catch (IOException e) {
       throw new DeserializationException(e);
     }

--- a/command/interface-adaptor-impl/src/main/java/com/github/j5ik2o/cqrs/es/java/command/interface_adaptor/repository/serialization/JacksonModuleFactory.java
+++ b/command/interface-adaptor-impl/src/main/java/com/github/j5ik2o/cqrs/es/java/command/interface_adaptor/repository/serialization/JacksonModuleFactory.java
@@ -1,0 +1,20 @@
+package com.github.j5ik2o.cqrs.es.java.command.interface_adaptor.repository.serialization;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.github.f4b6a3.ulid.Ulid;
+import com.github.j5ik2o.cqrs.es.java.domain.groupchat.Members;
+import com.github.j5ik2o.cqrs.es.java.domain.groupchat.Messages;
+
+public class JacksonModuleFactory {
+  public static Module create() {
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(Ulid.class, new UlidJsonSerializer());
+    module.addDeserializer(Ulid.class, new UlidJsonDeserializer());
+    module.addSerializer(Members.class, new MembersJsonSerializer());
+    module.addDeserializer(Members.class, new MembersJsonDeserializer());
+    module.addSerializer(Messages.class, new MessagesJsonSerializer());
+    module.addDeserializer(Messages.class, new MessagesJsonDeserializer());
+    return module;
+  }
+}

--- a/command/processor/src/main/java/com/github/j5ik2o/cqrs/es/java/command/processor/GroupChatCommandProcessor.java
+++ b/command/processor/src/main/java/com/github/j5ik2o/cqrs/es/java/command/processor/GroupChatCommandProcessor.java
@@ -6,9 +6,11 @@ import com.github.j5ik2o.cqrs.es.java.domain.useraccount.UserAccountId;
 import io.vavr.Tuple2;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("write")
 public class GroupChatCommandProcessor {
 
   private final GroupChatRepository groupChatRepository;

--- a/rmu/src/main/java/com/github/j5ik2o/cqrs/es/java/rmu/ReadModelUpdater.java
+++ b/rmu/src/main/java/com/github/j5ik2o/cqrs/es/java/rmu/ReadModelUpdater.java
@@ -6,6 +6,7 @@ import com.github.j5ik2o.cqrs.es.java.domain.groupchat.GroupChatEvent;
 import com.github.j5ik2o.cqrs.es.java.domain.groupchat.MemberId;
 import com.github.j5ik2o.cqrs.es.java.rmu.dao.*;
 import com.github.j5ik2o.event.store.adapter.java.DeserializationException;
+import java.nio.ByteBuffer;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -27,81 +28,106 @@ public class ReadModelUpdater {
         .getRecords()
         .forEach(
             record -> {
-              var streamRecord = record.getDynamodb();
-              if (streamRecord == null) {
-                throw new IllegalStateException("streamRecord is null");
-              }
-              var attributeValues = streamRecord.getNewImage();
-              if (attributeValues == null) {
-                throw new IllegalStateException("attributeValues is null");
-              }
-              var payloadAttr = attributeValues.get("payload");
-              if (payloadAttr == null || payloadAttr.isNULL()) {
-                throw new IllegalStateException("Payload is missing or not a binary type");
-              }
-              var payloadBytes = payloadAttr.getB();
+              var payloadBytes = getByteBuffer(record);
               try {
                 GroupChatEvent groupChatEvent =
                     serializer.deserialize(payloadBytes.array(), GroupChatEvent.class);
                 if (groupChatEvent instanceof GroupChatEvent.Created typedEvent) {
-                  var groupChatRecord =
-                      new GroupChatRecord(
-                          typedEvent.aggregateId().asString(),
-                          typedEvent.name().asString(),
-                          typedEvent.executorId().asString(),
-                          typedEvent.occurredAt(),
-                          typedEvent.occurredAt());
-                  groupChatMapper.insertGroupChat(groupChatRecord);
-                  var memberId = MemberId.generate();
-                  var memberRecord =
-                      new MemberRecord(
-                          memberId.asString(),
-                          typedEvent.aggregateId().asString(),
-                          typedEvent.executorId().asString(),
-                          typedEvent.occurredAt(),
-                          typedEvent.occurredAt());
-                  memberMapper.insertMember(memberRecord);
+                  insertGroupChat(typedEvent);
                 } else if (groupChatEvent instanceof GroupChatEvent.Deleted typedEvent) {
-                  groupChatMapper.deleteGroupChat(typedEvent.aggregateId().asString());
+                  deleteGroupChat(typedEvent);
                 } else if (groupChatEvent instanceof GroupChatEvent.Renamed typedEvent) {
-                  var groupChatRecord =
-                      new GroupChatRecord(
-                          typedEvent.aggregateId().asString(),
-                          typedEvent.name().asString(),
-                          typedEvent.executorId().asString(),
-                          typedEvent.occurredAt(),
-                          typedEvent.occurredAt());
-                  groupChatMapper.updateGroupChat(groupChatRecord);
+                  renameGroupChat(typedEvent);
                 } else if (groupChatEvent instanceof GroupChatEvent.MemberAdded typedEvent) {
-                  var memberId = MemberId.generate();
-                  var memberRecord =
-                      new MemberRecord(
-                          memberId.asString(),
-                          typedEvent.aggregateId().asString(),
-                          typedEvent.executorId().asString(),
-                          typedEvent.occurredAt(),
-                          typedEvent.occurredAt());
-                  memberMapper.insertMember(memberRecord);
+                  insertMember(typedEvent);
                 } else if (groupChatEvent instanceof GroupChatEvent.MemberRemoved typedEvent) {
-                  memberMapper.deleteMember(
-                      typedEvent.aggregateId().asString(),
-                      typedEvent.member().getUserAccountId().asString());
+                  removeMember(typedEvent);
                 } else if (groupChatEvent instanceof GroupChatEvent.MessagePosted typedEvent) {
-                  var messageRecord =
-                      new MessageRecord(
-                          typedEvent.getId(),
-                          typedEvent.aggregateId().asString(),
-                          typedEvent.message().getContent(),
-                          typedEvent.message().getSenderId().asString(),
-                          typedEvent.occurredAt(),
-                          typedEvent.occurredAt());
-                  messageMapper.insertMessage(messageRecord);
+                  insertMessage(typedEvent);
                 } else if (groupChatEvent instanceof GroupChatEvent.MessageDeleted typedEvent) {
-                  messageMapper.deleteMessage(typedEvent.aggregateId().asString());
+                  deleteMessage(typedEvent);
                 }
               } catch (DeserializationException e) {
                 throw new IllegalStateException("Failed to deserialize event", e);
               }
             });
+  }
+
+  private static ByteBuffer getByteBuffer(DynamodbEvent.DynamodbStreamRecord record) {
+    var streamRecord = record.getDynamodb();
+    if (streamRecord == null) {
+      throw new IllegalStateException("streamRecord is null");
+    }
+    var attributeValues = streamRecord.getNewImage();
+    if (attributeValues == null) {
+      throw new IllegalStateException("attributeValues is null");
+    }
+    var payloadAttr = attributeValues.get("payload");
+    if (payloadAttr == null || payloadAttr.isNULL()) {
+      throw new IllegalStateException("Payload is missing or not a binary type");
+    }
+    return payloadAttr.getB();
+  }
+
+  private void deleteMessage(GroupChatEvent.MessageDeleted typedEvent) {
+    messageMapper.deleteMessage(typedEvent.aggregateId().asString());
+  }
+
+  private void deleteGroupChat(GroupChatEvent.Deleted typedEvent) {
+    groupChatMapper.deleteGroupChat(typedEvent.aggregateId().asString());
+  }
+
+  private void removeMember(GroupChatEvent.MemberRemoved typedEvent) {
+    memberMapper.deleteMember(
+        typedEvent.aggregateId().asString(), typedEvent.member().getUserAccountId().asString());
+  }
+
+  private void insertMember(GroupChatEvent.MemberAdded typedEvent) {
+    var memberId = MemberId.generate();
+    var memberRecord =
+        new MemberRecord(
+            memberId.asString(),
+            typedEvent.aggregateId().asString(),
+            typedEvent.executorId().asString(),
+            typedEvent.occurredAt(),
+            typedEvent.occurredAt());
+    memberMapper.insertMember(memberRecord);
+  }
+
+  private void insertMessage(GroupChatEvent.MessagePosted typedEvent) {
+    var messageRecord =
+        new MessageRecord(
+            typedEvent.getId(),
+            typedEvent.aggregateId().asString(),
+            typedEvent.message().getContent(),
+            typedEvent.message().getSenderId().asString(),
+            typedEvent.occurredAt(),
+            typedEvent.occurredAt());
+    messageMapper.insertMessage(messageRecord);
+  }
+
+  private void renameGroupChat(GroupChatEvent.Renamed typedEvent) {
+    groupChatMapper.updateGroupChatName(
+        typedEvent.aggregateId().asString(), typedEvent.name().asString());
+  }
+
+  private void insertGroupChat(GroupChatEvent.Created typedEvent) {
+    var groupChatRecord =
+        new GroupChatRecord(
+            typedEvent.aggregateId().asString(),
+            typedEvent.name().asString(),
+            typedEvent.executorId().asString(),
+            typedEvent.occurredAt(),
+            typedEvent.occurredAt());
+    groupChatMapper.insertGroupChat(groupChatRecord);
+    var memberId = MemberId.generate();
+    var memberRecord =
+        new MemberRecord(
+            memberId.asString(),
+            typedEvent.aggregateId().asString(),
+            typedEvent.executorId().asString(),
+            typedEvent.occurredAt(),
+            typedEvent.occurredAt());
+    memberMapper.insertMember(memberRecord);
   }
 }

--- a/rmu/src/main/java/com/github/j5ik2o/cqrs/es/java/rmu/dao/GroupChatMapper.java
+++ b/rmu/src/main/java/com/github/j5ik2o/cqrs/es/java/rmu/dao/GroupChatMapper.java
@@ -17,6 +17,10 @@ public interface GroupChatMapper {
   @Flush
   int updateGroupChat(GroupChatRecord groupChatRecord);
 
+  @Update("UPDATE group_chats SET name = #{name}, updated_at = #{updatedAt} WHERE id = #{id}")
+  @Flush
+  int updateGroupChatName(String id, String name);
+
   @Update("UPDATE group_chats SET disabled = 1 WHERE id = #{id}")
   @Flush
   int deleteGroupChat(String id);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Introduced `CommandLineRunnerImpl` for executing code upon application startup under the "local-rmu" profile.
- New Feature: Added "write" profile to `RepositoryConfig` and `GroupChatCommandProcessor` classes, enabling selective bean creation.
- Refactor: Simplified ObjectMapper configuration in `GroupChatEventSerializer` and `GroupChatSnapshotSerializer` using `JacksonModuleFactory.create()`.
- Refactor: Improved readability in `ReadModelUpdater` by extracting logic into separate methods.
- New Feature: Added `updateGroupChatName` method in `GroupChatMapper` for updating group chat names in the database.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->